### PR TITLE
Add test_mds_dmclock_qos.py to teuthology test & vstart_runner test

### DIFF
--- a/qa/suites/fs/verify/tasks/mds-dmclock-qos.yaml
+++ b/qa/suites/fs/verify/tasks/mds-dmclock-qos.yaml
@@ -1,0 +1,5 @@
+
+tasks:
+  - cephfs_test_runner:
+      modules:
+        - tasks.cephfs.test_mds_dmclock_qos

--- a/qa/tasks/cephfs/mount.py
+++ b/qa/tasks/cephfs/mount.py
@@ -672,7 +672,7 @@ class CephFSMount(object):
         stdout = kwargs.pop('stdout', StringIO())
         stderr = kwargs.pop('stderr', StringIO())
 
-        return self.client_remote.run(args=args, cwd=cwd, timeout=timeout, stdout=stdout, stderr=stderr, **kwargs)
+        return self.client_remote.run(args=args, cwd=cwd, timeout=timeout, stdout=stdout, stderr=stderr, omit_sudo=omit_sudo, **kwargs)
 
     def run_shell_payload(self, payload, **kwargs):
         return self.run_shell(["bash", "-c", Raw(f"'{payload}'")], **kwargs)

--- a/qa/tasks/cephfs/test_mds_dmclock_qos.py
+++ b/qa/tasks/cephfs/test_mds_dmclock_qos.py
@@ -1,0 +1,241 @@
+from tasks.cephfs.cephfs_test_case import CephFSTestCase
+from teuthology.exceptions import CommandFailedError
+
+import logging
+
+log = logging.getLogger(__name__)
+
+class TestMDSDmclockQoS(CephFSTestCase):
+
+    CLIENTS_REQUIRED = 2
+    MDSS_REQUIRED = 3
+    REQUIRE_FILESYSTEM = True
+
+    TEST_SUBVOLUME_PREFIX = "subvolume_"
+    TEST_SUBVOLUME_COUNT = 2
+    TEST_DIR_COUNT = 20
+    subvolumes = []
+
+    def setUp(self):
+        super(TestMDSDmclockQoS, self).setUp()
+
+        self._fs_cmd("set", self.fs.name, "max_mds", str(self.MDSS_REQUIRED))
+
+        # create test subvolumes
+        self.subvolumes = [self.TEST_SUBVOLUME_PREFIX + str(i)\
+                for i in range(self.TEST_SUBVOLUME_COUNT)]
+
+        # create subvolumes
+        for subv_ in self.subvolumes:
+            self._fs_cmd("subvolume", "create", self.fs.name, subv_)
+
+        self.mount_a.umount_wait()
+        self.mount_b.umount_wait()
+
+        self.mount_a.mount(cephfs_mntpt=self.get_subvolume_path(self.subvolumes[0]))
+        self.mount_b.mount(cephfs_mntpt=self.get_subvolume_path(self.subvolumes[1]))
+
+        # chown root to user
+        from os import getuid, getgid
+        self.mount_a.run_shell(['sudo', 'chown', "{0}:{1}".format(getuid(), getgid()), self.mount_a.hostfs_mntpt])
+        self.mount_b.run_shell(['sudo', 'chown', "{0}:{1}".format(getuid(), getgid()), self.mount_b.hostfs_mntpt])
+
+    def _fs_cmd(self, *args):
+        return self.mgr_cluster.mon_manager.raw_cluster_cmd("-c", "ceph.conf", "-k", "keyring", "fs", *args)
+
+    def mds_asok_all(self, commands):
+        """
+        admin socket command to all active mds
+        """
+        from copy import deepcopy
+
+        origin = deepcopy(commands)
+        for id in self.fs.mds_ids:
+            self.fs.mds_asok(commands, mds_id=id)
+            commands = deepcopy(origin)
+
+    def get_subvolume_path(self, subvolume_name):
+        return self._fs_cmd("subvolume", "getpath", self.fs.name, subvolume_name).rstrip()
+
+    def enable_qos(self):
+        self.mds_asok_all(["config", "set", "mds_dmclock_mds_qos_enable", "true"])
+
+    def dump_qos(self):
+        """
+        Get dump qos from all active mds, and then compare the result for each voluem_id.
+        if dump qos results for each volume_id are different, assert it.
+        """
+        result ={}
+
+        for id in self.fs.mds_ids:
+            out = self.fs.mds_asok(["dump", "qos"], mds_id=id)  # out == list of volume qos info
+            for volume_qos in out:
+                self.assertIn("volume_id", volume_qos)
+
+                if volume_qos["volume_id"] in result:
+                    self.assertEqual(volume_qos, result[volume_qos["volume_id"]])
+                result[volume_qos["volume_id"]] = volume_qos
+
+        return list(result.values())
+
+    def test_enable_qos(self):
+        """
+        Enable QoS for all active mdss.
+        """
+        self.enable_qos()
+
+        stat_qos = self.dump_qos()
+
+        self.assertNotEqual(stat_qos, [])
+
+    def test_disable_qos(self):
+        """
+        Disable QoS for all active mdss.
+        """
+        self.mds_asok_all(["config", "set", "mds_dmclock_mds_qos_enable", "false"])
+
+        stat_qos = self.dump_qos()
+
+        self.assertEqual(stat_qos, [])
+
+    def test_set_default_qos_value(self):
+        """
+        Enable QoS and set default qos value, and then check the result.
+        """
+        self.enable_qos()
+
+        reservation, weight, limit = 200, 200, 200
+
+        self.mds_asok_all(["config", "set", "mds_dmclock_mds_qos_default_reservation", str(reservation)])
+        self.mds_asok_all(["config", "set", "mds_dmclock_mds_qos_default_limit", str(limit)])
+        self.mds_asok_all(["config", "set", "mds_dmclock_mds_qos_default_weight", str(weight)])
+
+        stat_qos = self.dump_qos()
+
+        for info in stat_qos:
+            self.assertIn("use_default", info)
+            if info["use_default"]:
+                self.assertEqual(info["reservation"], reservation)
+                self.assertEqual(info["limit"], limit)
+                self.assertEqual(info["weight"], weight)
+
+    def test_update_qos_value(self):
+        """
+        Update qos 3 values using setfattr.
+        Check its result via getfattr and dump qos.
+        """
+        self.enable_qos()
+
+        reservation, weight, limit = 100, 100, 100
+
+        self.mount_a.setfattr(self.mount_a.hostfs_mntpt, "ceph.dmclock.mds_reservation", str(reservation))
+        self.mount_a.setfattr(self.mount_a.hostfs_mntpt, "ceph.dmclock.mds_limit", str(limit))
+        self.mount_a.setfattr(self.mount_a.hostfs_mntpt, "ceph.dmclock.mds_weight", str(weight))
+
+        # check updated vxattr using getfattr
+        self.assertEqual(
+                int(float(self.mount_a.getfattr(self.mount_a.hostfs_mntpt, "ceph.dmclock.mds_reservation"))),
+                reservation)
+        self.assertEqual(
+                int(float(self.mount_a.getfattr(self.mount_a.hostfs_mntpt, "ceph.dmclock.mds_weight"))),
+                weight)
+        self.assertEqual(
+                int(float(self.mount_a.getfattr(self.mount_a.hostfs_mntpt, "ceph.dmclock.mds_limit"))),
+                limit)
+
+        stat_qos = self.dump_qos()
+        log.info(stat_qos)
+
+        # check updated dmclock info using dump qos
+        for info in stat_qos:
+            self.assertIn("volume_id", info)
+            if info["volume_id"] == self.get_subvolume_path(self.subvolumes[0]):
+                self.assertEqual(info["reservation"], reservation)
+                self.assertEqual(info["limit"], limit)
+                self.assertEqual(info["weight"], weight)
+
+    def test_remote_update_qos_value(self):
+        """
+        Update qos 3 values using setfattr.
+        And check it from another mount path.
+        """
+        self.enable_qos()
+
+        self.mount_b.umount_wait()
+        self.mount_b.mount(cephfs_mntpt=self.get_subvolume_path(self.subvolumes[0]))
+
+        reservation, weight, limit = 50, 50, 50
+
+        self.mount_a.setfattr(self.mount_a.hostfs_mntpt, "ceph.dmclock.mds_reservation", str(reservation))
+        self.mount_a.setfattr(self.mount_a.hostfs_mntpt, "ceph.dmclock.mds_limit", str(limit))
+        self.mount_a.setfattr(self.mount_a.hostfs_mntpt, "ceph.dmclock.mds_weight", str(weight))
+
+        # check remote vxattr
+        self.assertEqual(
+                int(float(self.mount_b.getfattr(self.mount_b.hostfs_mntpt, "ceph.dmclock.mds_reservation"))),
+                reservation)
+        self.assertEqual(
+                int(float(self.mount_b.getfattr(self.mount_b.hostfs_mntpt, "ceph.dmclock.mds_weight"))),
+                weight)
+        self.assertEqual(
+                int(float(self.mount_b.getfattr(self.mount_b.hostfs_mntpt, "ceph.dmclock.mds_limit"))),
+                limit)
+
+    def test_qos_ratio(self):
+        """
+        Test QoS throttling.
+        For each subvolume, test QoS using thread.
+        """
+        import threading
+
+        def create_dirs(self, tid, base_path):
+            from os import path, mkdir
+            import time
+
+            base = path.join(base_path, "thread_{0}".format(tid))
+            mkdir(base)
+
+            start = time.time()
+
+            for i in range(self.TEST_DIR_COUNT):
+                mkdir(path.join(base, "dir_{0}".format(i)))
+                for j in range(self.TEST_DIR_COUNT):
+                    mkdir(path.join(base, "dir_{0}".format(i), "subdir_{0}".format(j)))
+
+            elapsed_time = time.time() - start
+
+            log.info("[Thread {0}]: mkdir {1} dirs in {2}secs, OPs/sec: {3}".format(
+                    tid, self.TEST_DIR_COUNT ** 2, elapsed_time, (self.TEST_DIR_COUNT ** 2) / elapsed_time))
+
+        self.enable_qos()
+
+        reservation, weight, limit = 100, 100, 100
+
+        self.mount_a.setfattr(self.mount_a.hostfs_mntpt, "ceph.dmclock.mds_reservation", str(reservation))
+        self.mount_a.setfattr(self.mount_a.hostfs_mntpt, "ceph.dmclock.mds_limit", str(limit))
+        self.mount_a.setfattr(self.mount_a.hostfs_mntpt, "ceph.dmclock.mds_weight", str(weight))
+
+        self.mount_b.setfattr(self.mount_b.hostfs_mntpt, "ceph.dmclock.mds_reservation", str(reservation * 2))
+        self.mount_b.setfattr(self.mount_b.hostfs_mntpt, "ceph.dmclock.mds_limit", str(limit * 2))
+        self.mount_b.setfattr(self.mount_b.hostfs_mntpt, "ceph.dmclock.mds_weight", str(weight * 2))
+
+        stat_qos = self.dump_qos()
+        log.info(stat_qos)
+
+        log.info("[Thread 0]: reservation: {0}, weight: {1}, limit {2}".format(reservation, weight, limit))
+        log.info("[Thread 1]: reservation: {0}, weight: {1}, limit {2}".format(reservation * 2, weight * 2, limit * 2))
+
+        threads = []
+        threads.append(threading.Thread(target=create_dirs, args=(self, 0, self.mount_a.hostfs_mntpt, )))
+        threads.append(threading.Thread(target=create_dirs, args=(self, 1, self.mount_b.hostfs_mntpt, )))
+
+        log.info("IO Testing...")
+
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+
+        stat_qos = self.dump_qos()
+        log.info(stat_qos)
+


### PR DESCRIPTION
Signed-off-by: Jinmyeong Lee <jinmyeong.lee@linecorp.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
