### PR TITLE
Update read_xattrs to enable qos when vid is root(/), test case to check QoS ratio

### DIFF
--- a/qa/tasks/cephfs/test_mds_dmclock_qos.py
+++ b/qa/tasks/cephfs/test_mds_dmclock_qos.py
@@ -18,8 +18,9 @@ class TestMDSDmclockQoS(CephFSTestCase):
 
     def setUp(self):
         super(TestMDSDmclockQoS, self).setUp()
+        self.fs.set_max_mds(self.MDSS_REQUIRED)
 
-        self._fs_cmd("set", self.fs.name, "max_mds", str(self.MDSS_REQUIRED))
+        #  self._fs_cmd("set", self.fs.name, "max_mds", str(self.MDSS_REQUIRED))
 
         # create test subvolumes
         self.subvolumes = [self.TEST_SUBVOLUME_PREFIX + str(i)\
@@ -60,12 +61,24 @@ class TestMDSDmclockQoS(CephFSTestCase):
     def enable_qos(self):
         self.mds_asok_all(["config", "set", "mds_dmclock_mds_qos_enable", "true"])
 
+    def is_equal_dict(self, a, b, ignore_key=[]):
+        ignore_key = set(ignore_key)
+        for key in a:
+            if key in ignore_key:
+                continue
+            if key not in b:
+                return False
+            if a[key] != b[key]:
+                return False
+        return True
+
     def dump_qos(self):
         """
         Get dump qos from all active mds, and then compare the result for each voluem_id.
         if dump qos results for each volume_id are different, assert it.
         """
         result ={}
+        ignore = ["session_cnt"]
 
         for id in self.fs.mds_ids:
             out = self.fs.mds_asok(["dump", "qos"], mds_id=id)  # out == list of volume qos info
@@ -73,7 +86,7 @@ class TestMDSDmclockQoS(CephFSTestCase):
                 self.assertIn("volume_id", volume_qos)
 
                 if volume_qos["volume_id"] in result:
-                    self.assertEqual(volume_qos, result[volume_qos["volume_id"]])
+                    self.assertTrue(self.is_equal_dict(volume_qos, result[volume_qos["volume_id"]], ignore_key=ignore))
                 result[volume_qos["volume_id"]] = volume_qos
 
         return list(result.values())
@@ -115,6 +128,44 @@ class TestMDSDmclockQoS(CephFSTestCase):
         for info in stat_qos:
             self.assertIn("use_default", info)
             if info["use_default"]:
+                self.assertEqual(info["reservation"], reservation)
+                self.assertEqual(info["limit"], limit)
+                self.assertEqual(info["weight"], weight)
+
+    def test_update_qos_value_root_volume(self):
+        """
+        Update qos 3 values using setfattr.
+        Check its result via getfattr and dump qos.
+        """
+        self.enable_qos()
+
+        reservation, weight, limit = 100, 100, 100
+
+        self.mount_a.umount_wait()
+        self.mount_a.mount(cephfs_mntpt="/")
+
+        self.mount_a.setfattr(self.mount_a.hostfs_mntpt, "ceph.dmclock.mds_reservation", str(reservation))
+        self.mount_a.setfattr(self.mount_a.hostfs_mntpt, "ceph.dmclock.mds_limit", str(limit))
+        self.mount_a.setfattr(self.mount_a.hostfs_mntpt, "ceph.dmclock.mds_weight", str(weight))
+
+        # check updated vxattr using getfattr
+        self.assertEqual(
+                int(float(self.mount_a.getfattr(self.mount_a.hostfs_mntpt, "ceph.dmclock.mds_reservation"))),
+                reservation)
+        self.assertEqual(
+                int(float(self.mount_a.getfattr(self.mount_a.hostfs_mntpt, "ceph.dmclock.mds_weight"))),
+                weight)
+        self.assertEqual(
+                int(float(self.mount_a.getfattr(self.mount_a.hostfs_mntpt, "ceph.dmclock.mds_limit"))),
+                limit)
+
+        stat_qos = self.dump_qos()
+        log.info(stat_qos)
+
+        # check updated dmclock info using dump qos
+        for info in stat_qos:
+            self.assertIn("volume_id", info)
+            if info["volume_id"] == self.get_subvolume_path(self.subvolumes[0]):
                 self.assertEqual(info["reservation"], reservation)
                 self.assertEqual(info["limit"], limit)
                 self.assertEqual(info["weight"], weight)
@@ -181,31 +232,43 @@ class TestMDSDmclockQoS(CephFSTestCase):
                 int(float(self.mount_b.getfattr(self.mount_b.hostfs_mntpt, "ceph.dmclock.mds_limit"))),
                 limit)
 
+    def test_qos_throttling_50(self):
+        import threading
+
+        self.enable_qos()
+
+        reservation, weight, limit = 50, 50, 50
+
+        self.mount_a.setfattr(self.mount_a.hostfs_mntpt, "ceph.dir.pin", str(1))
+
+        self.mount_a.setfattr(self.mount_a.hostfs_mntpt, "ceph.dmclock.mds_reservation", str(reservation))
+        self.mount_a.setfattr(self.mount_a.hostfs_mntpt, "ceph.dmclock.mds_limit", str(limit))
+        self.mount_a.setfattr(self.mount_a.hostfs_mntpt, "ceph.dmclock.mds_weight", str(weight))
+
+        stat_qos = self.dump_qos()
+        log.info(stat_qos)
+
+        threads = []
+        results = [0]
+
+        threads.append(threading.Thread(target=create_dirs, args=(0, self.mount_a.hostfs_mntpt, self.TEST_DIR_COUNT, results)))
+
+        log.info("IO Testing...")
+
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+
+        stat_qos = self.dump_qos()
+        log.info(stat_qos)
+
     def test_qos_ratio(self):
         """
         Test QoS throttling.
         For each subvolume, test QoS using thread.
         """
         import threading
-
-        def create_dirs(self, tid, base_path):
-            from os import path, mkdir
-            import time
-
-            base = path.join(base_path, "thread_{0}".format(tid))
-            mkdir(base)
-
-            start = time.time()
-
-            for i in range(self.TEST_DIR_COUNT):
-                mkdir(path.join(base, "dir_{0}".format(i)))
-                for j in range(self.TEST_DIR_COUNT):
-                    mkdir(path.join(base, "dir_{0}".format(i), "subdir_{0}".format(j)))
-
-            elapsed_time = time.time() - start
-
-            log.info("[Thread {0}]: mkdir {1} dirs in {2}secs, OPs/sec: {3}".format(
-                    tid, self.TEST_DIR_COUNT ** 2, elapsed_time, (self.TEST_DIR_COUNT ** 2) / elapsed_time))
 
         self.enable_qos()
 
@@ -226,8 +289,9 @@ class TestMDSDmclockQoS(CephFSTestCase):
         log.info("[Thread 1]: reservation: {0}, weight: {1}, limit {2}".format(reservation * 2, weight * 2, limit * 2))
 
         threads = []
-        threads.append(threading.Thread(target=create_dirs, args=(self, 0, self.mount_a.hostfs_mntpt, )))
-        threads.append(threading.Thread(target=create_dirs, args=(self, 1, self.mount_b.hostfs_mntpt, )))
+        results = [0, 0]
+        threads.append(threading.Thread(target=create_dirs, args=(0, self.mount_a.hostfs_mntpt, self.TEST_DIR_COUNT, results)))
+        threads.append(threading.Thread(target=create_dirs, args=(1, self.mount_b.hostfs_mntpt, self.TEST_DIR_COUNT, results)))
 
         log.info("IO Testing...")
 
@@ -238,4 +302,28 @@ class TestMDSDmclockQoS(CephFSTestCase):
 
         stat_qos = self.dump_qos()
         log.info(stat_qos)
+
+        self.assertGreaterEqual(results[0] * 2, results[1] * 0.8)
+        self.assertLessEqual(results[0] * 2, results[1] * 1.2)
+
+
+def create_dirs(tid, base_path, TEST_DIR_COUNT, results):
+    from os import path, mkdir
+    import time
+
+    base = path.join(base_path, "thread_{0}".format(tid))
+    mkdir(base)
+
+    start = time.time()
+
+    for i in range(TEST_DIR_COUNT):
+        mkdir(path.join(base, "dir_{0}".format(i)))
+        for j in range(TEST_DIR_COUNT):
+            mkdir(path.join(base, "dir_{0}".format(i), "subdir_{0}".format(j)))
+
+    elapsed_time = time.time() - start
+
+    results[tid] = (TEST_DIR_COUNT ** 2) / elapsed_time
+    log.info("[Thread {0}]: mkdir {1} dirs in {2}secs, OPs/sec: {3}".format(
+            tid, TEST_DIR_COUNT ** 2, elapsed_time, (TEST_DIR_COUNT ** 2) / elapsed_time))
 

--- a/src/mds/MDSDmclockScheduler.cc
+++ b/src/mds/MDSDmclockScheduler.cc
@@ -475,12 +475,16 @@ CInode *MDSDmclockScheduler::read_xattrs(const VolumeId vid)
   auto qos_msg = make_message<MDSDmclockQoS>(vid);
   CF_MDS_RetryMessageFactory cf(mds, qos_msg);
 
-  // Do not need to set qos at ROOT_VOLUME_ID
   if (vid != ROOT_VOLUME_ID) {
     CInode *cur = mds->mdcache->get_inode(path_.get_ino());  //get base_ino
     
     mds->mdcache->discover_path(cur, CEPH_NOSNAP, path_, NULL, false);	// must discover
     if (mds->logger) mds->logger->inc(l_mds_traverse_discover);
+  }
+  else { // vid == "/"
+    if (mds->get_nodeid() != mds->mdsmap->get_root()) {
+      mds->mdcache->discover_base_ino(MDS_INO_ROOT, cf.build(), mds->mdsmap->get_root());
+    }
   }
 
   MDRequestRef null_ref;


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
