### PR TITLE
mds/qa/unittest: QoS xattr manipulation is allowed only for subvolume path

### DIFF
--- a/src/mds/MDSDmclockScheduler.h
+++ b/src/mds/MDSDmclockScheduler.h
@@ -271,6 +271,7 @@ private:
   Queue *dmclock_queue;
   std::map<VolumeId, VolumeInfo> volume_info_map;
   mutable std::mutex volume_info_lock;
+  static constexpr uint32_t SUBVOL_ROOT_DEPTH = 3;
 
 public:
 
@@ -328,8 +329,9 @@ public:
   void enqueue_update_request(const VolumeId& vid, RequestCB cb_func);
   uint32_t get_request_queue_size() const;
 
-  const VolumeId& get_volume_id(Session *session);
+  const VolumeId get_volume_id(Session *session);
   const SessionId get_session_id(Session *session);
+  const VolumeId convert_subvol_root(const VolumeId& volume_id);
 
   using RejectThreshold = Time;
   using AtLimitParam = boost::variant<AtLimit, RejectThreshold>;

--- a/src/test/mds/TestDmclockScheduler.cc
+++ b/src/test/mds/TestDmclockScheduler.cc
@@ -224,7 +224,21 @@ TEST(MDSDmclockScheduler, SessionSanity)
 
   /* duplicate */
   scheduler->delete_qos_info_by_session(session);
+  put_session(session);
 
+  VolumeId mount_root_path = "/volumes/_nogroup/4c55ad20-9c44-4a5e-9233-8ac64340b98c/subdir";
+  VolumeId subvol_root_path = scheduler->convert_subvol_root(mount_root_path);
+  scheduler->create_volume_info(subvol_root_path, 100.0, 300.0, 400.0, false);
+  session = make_session(mount_root_path, 10000);
+
+  scheduler->create_qos_info_from_xattr(session);
+  ASSERT_EQ(scheduler->get_volume_info_map().size(), 1);
+  ASSERT_TRUE(scheduler->copy_volume_info(subvol_root_path, vi));
+  ASSERT_EQ(vi.get_session_cnt(), 1);
+
+  scheduler->delete_qos_info_by_session(session);
+  ASSERT_EQ(scheduler->get_volume_info_map().size(), 0);
+  ASSERT_FALSE(scheduler->copy_volume_info(vid, vi));
   put_session(session);
 
   #define SESSION_NUM 10


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
