### PR TITLE
mds: Add dmclock single parameter set up function

### DIFF
--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -5484,6 +5484,7 @@ int Server::tokenize_qos_vxattr(string name, string value, dmclock_info_t *info)
   dout(20) << __func__ << " called name: " << name << ", value: " << value << dendl;
 
   std::vector<std::string> tokens;
+  boost::algorithm::trim(value);
   boost::split(tokens, value, boost::is_any_of(" "));
 
   if (tokens.size() > 3 || tokens.size() <= 0) {
@@ -5491,11 +5492,11 @@ int Server::tokenize_qos_vxattr(string name, string value, dmclock_info_t *info)
   }
 
   for (auto token: tokens) {
+    dout(20) << "token: " << token << dendl;
     std::vector<std::string> type_value;
     boost::split(type_value, token, boost::is_any_of("="));
-    dout(20) << "token: " << token << dendl;
 
-    if (type_value.size() > 2) {
+    if (type_value.size() != 2) {
       return -EINVAL;
     }
 

--- a/src/mds/Server.h
+++ b/src/mds/Server.h
@@ -37,7 +37,7 @@
 
 #include <boost/algorithm/string/classification.hpp>
 #include <boost/algorithm/string/split.hpp>
-#include<boost/algorithm/string.hpp>
+#include <boost/algorithm/string/trim_all.hpp>
 
 class OSDMap;
 class LogEvent;

--- a/src/mds/Server.h
+++ b/src/mds/Server.h
@@ -35,6 +35,10 @@
 #include "Mutation.h"
 #include "MDSContext.h"
 
+#include <boost/algorithm/string/classification.hpp>
+#include <boost/algorithm/string/split.hpp>
+#include<boost/algorithm/string.hpp>
+
 class OSDMap;
 class LogEvent;
 class EMetaBlob;
@@ -210,6 +214,7 @@ public:
 
   int parse_quota_vxattr(string name, string value, quota_info_t *quota);
   int parse_qos_vxattr(string name, string value, dmclock_info_t *info);
+  int tokenize_qos_vxattr(string name, string value, dmclock_info_t *info);
   void create_quota_realm(CInode *in);
   int parse_layout_vxattr(string name, string value, const OSDMap& osdmap,
 			  file_layout_t *layout, bool validate=true);


### PR DESCRIPTION
Added Usage:
setfattr -n ceph.dmclock -v "mds_reservation=100 mds_weight=300 mds_limit=500" mnt_pt
setfattr -n ceph.dmclock -v "mds_reservation=50 mds_weight=200" mnt_pt
setfattr -n ceph.dmclock -v "mds_reservation=70" mnt_pt

Also, works well with below origin usage.
setfattr -n ceph.dmclock.mds_reservation -v 50 mnt_pt
setfattr -n ceph.dmclock.mds_weight -v 50 mnt_pt
setfattr -n ceph.dmclock.mds_limit -v 100 mnt_pt

Signed-off-by: Jinmyeong Lee <jinmyeong.lee@linecorp.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
